### PR TITLE
Fix the path specified while mounting the frontend volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   backend:
@@ -20,7 +20,7 @@ services:
       - "3000:3000"
     volumes:
       - ./frontend:/app
-      - /frontend/node_modules
+      - /app/node_modules
     environment:
       - NODE_ENV=development
     depends_on:


### PR DESCRIPTION
When I ran the docker compose command, I ran into this error:
``` 
chaatra-frontend-1  | sh: 1: react-scripts: not found
chaatra-frontend-1 exited with code 127
```
I went into the frontend folder and ran `npm install` before running docker compose, and it worked again. I then made this fix in the frontend Dockerfile, which had mounted the `node_modules` folder to a wrong path. 

This PR fixes that problem.